### PR TITLE
[Issue 2] Android: cannot use taskaction annotation on method

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
+  namespace = "com.reactnativenotificationchannels"
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-NotificationChannels_kotlinVersion=1.3.50
-NotificationChannels_compileSdkVersion=29
-NotificationChannels_buildToolsVersion=29.0.2
-NotificationChannels_targetSdkVersion=29
+NotificationChannels_kotlinVersion=1.9.0
+NotificationChannels_compileSdkVersion=33
+NotificationChannels_buildToolsVersion=33.0.0
+NotificationChannels_targetSdkVersion=33

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-NotificationChannels_kotlinVersion=1.9.0
+NotificationChannels_kotlinVersion=1.7.22
 NotificationChannels_compileSdkVersion=33
 NotificationChannels_buildToolsVersion=33.0.0
 NotificationChannels_targetSdkVersion=33

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-notification-channels",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A package for react-native consisting of native android helper functions to create Notification channels.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",


### PR DESCRIPTION
- Updated versions in grade.properties
- added namespace in build.gradle
- this will support newest version of react native